### PR TITLE
Display correct URL scheme in OpenAPI URLs

### DIFF
--- a/cardea-server/src/main/resources/application.yml
+++ b/cardea-server/src/main/resources/application.yml
@@ -13,5 +13,10 @@ spring:
       # Disable UserDetailsServiceAutoConfiguration to prevent auto-creation of a test user
       - org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration
 
+# Ensure OpenAPI docs display correct URL when server is behind a proxy
+server:
+  use-forwarded-headers: true
+  forward-headers-strategy: framework
+
 build:
   version: "@project.version@"

--- a/changes/fix_openapi_url_scheme.md
+++ b/changes/fix_openapi_url_scheme.md
@@ -1,0 +1,1 @@
+OpenAPI URLs now displays correct URL scheme

--- a/example-application.properties
+++ b/example-application.properties
@@ -7,7 +7,3 @@ instancename=
 
 ## directory containing QC Gate data files
 datadirectory=
-
-# Ensure OpenAPI docs display correct URL when server is behind a proxy
-server.use-forwarded-headers=true
-server.forward-headers-strategy=framework

--- a/example-application.properties
+++ b/example-application.properties
@@ -10,3 +10,4 @@ datadirectory=
 
 # Ensure OpenAPI docs display correct URL when server is behind a proxy
 server.use-forwarded-headers=true
+server.forward-headers-strategy=framework


### PR DESCRIPTION
Jira ticket:

- [x] Includes a change file
- [ ] Updates developer documentation

Fixes an issue where requests for anything more complex than a timestamp were failing in the OpenAPI docs when deployed behind an nginx proxy.