### PR TITLE
Add requisition-cases queryable endpoint

### DIFF
--- a/cardea-data/src/main/java/ca/on/oicr/gsi/cardea/data/CaseData.java
+++ b/cardea-data/src/main/java/ca/on/oicr/gsi/cardea/data/CaseData.java
@@ -5,21 +5,29 @@ import static java.util.Objects.requireNonNull;
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Immutable CaseData
  */
 public class CaseData {
 
+  private final Map<Long, Assay> assaysById;
   private final List<Case> cases;
   private final List<OmittedSample> omittedSamples;
   private final ZonedDateTime timestamp;
 
-  public CaseData(List<Case> cases, List<OmittedSample> omittedSamples, ZonedDateTime timestamp) {
+  public CaseData(List<Case> cases, List<OmittedSample> omittedSamples, Map<Long, Assay> assaysById,
+      ZonedDateTime timestamp) {
+    this.assaysById = Collections.unmodifiableMap(assaysById);
     this.cases = unmodifiableList(cases);
     this.omittedSamples = Collections.unmodifiableList(omittedSamples);
     this.timestamp = requireNonNull(timestamp);
 
+  }
+
+  public Map<Long, Assay> getAssaysById() {
+    return assaysById;
   }
 
   public List<Case> getCases() {

--- a/cardea-data/src/main/java/ca/on/oicr/gsi/cardea/data/CasesForRequisition.java
+++ b/cardea-data/src/main/java/ca/on/oicr/gsi/cardea/data/CasesForRequisition.java
@@ -11,13 +11,13 @@ import static java.util.Objects.requireNonNull;
  * A set of Cases that all have the same requisition (and therefore the same
  * assay)
  */
-public class DjerbaCases {
+public class CasesForRequisition {
 
   private final String assayName;
   private final String assayVersion;
   private final Set<Case> cases;
 
-  private DjerbaCases(Builder builder) {
+  private CasesForRequisition(Builder builder) {
     // older assays might be null
     this.assayName = builder.assayName;
     this.assayVersion = builder.assayVersion;
@@ -42,8 +42,8 @@ public class DjerbaCases {
     private String assayVersion;
     private Set<Case> cases;
 
-    public DjerbaCases build() {
-      return new DjerbaCases(this);
+    public CasesForRequisition build() {
+      return new CasesForRequisition(this);
     }
 
     public Builder assayName(String assayName) {

--- a/cardea-data/src/main/java/ca/on/oicr/gsi/cardea/data/DjerbaCases.java
+++ b/cardea-data/src/main/java/ca/on/oicr/gsi/cardea/data/DjerbaCases.java
@@ -1,0 +1,64 @@
+package ca.on.oicr.gsi.cardea.data;
+
+import java.util.Set;
+
+import static java.util.Collections.unmodifiableSet;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Immutable DjerbaCases
+ * 
+ * A set of Cases that all have the same requisition (and therefore the same
+ * assay)
+ */
+public class DjerbaCases {
+
+  private final String assayName;
+  private final String assayVersion;
+  private final Set<Case> cases;
+
+  private DjerbaCases(Builder builder) {
+    // older assays might be null
+    this.assayName = builder.assayName;
+    this.assayVersion = builder.assayVersion;
+    this.cases = unmodifiableSet(requireNonNull(builder.cases));
+  }
+
+  public String getAssayName() {
+    return assayName;
+  }
+
+  public String getAssayVersion() {
+    return assayVersion;
+  }
+
+  public Set<Case> getCases() {
+    return cases;
+  }
+
+  public static class Builder {
+
+    private String assayName;
+    private String assayVersion;
+    private Set<Case> cases;
+
+    public DjerbaCases build() {
+      return new DjerbaCases(this);
+    }
+
+    public Builder assayName(String assayName) {
+      this.assayName = assayName;
+      return this;
+    }
+
+    public Builder assayVersion(String assayVersion) {
+      this.assayVersion = assayVersion;
+      return this;
+    }
+
+    public Builder cases(Set<Case> cases) {
+      this.cases = cases;
+      return this;
+    }
+  }
+}

--- a/cardea-server/src/main/java/ca/on/oicr/gsi/cardea/server/CaseLoader.java
+++ b/cardea-server/src/main/java/ca/on/oicr/gsi/cardea/server/CaseLoader.java
@@ -145,7 +145,7 @@ public class CaseLoader {
         refreshTimer.record(System.currentTimeMillis() - startTimeMillis, TimeUnit.MILLISECONDS);
       }
 
-      CaseData caseData = new CaseData(cases, omittedSamples, afterTimestamp);
+      CaseData caseData = new CaseData(cases, omittedSamples, assaysById, afterTimestamp);
 
       log.debug(String.format("Completed loading %d cases.", cases.size()));
 

--- a/cardea-server/src/main/java/ca/on/oicr/gsi/cardea/server/controller/CardeaApiController.java
+++ b/cardea-server/src/main/java/ca/on/oicr/gsi/cardea/server/controller/CardeaApiController.java
@@ -3,7 +3,7 @@ package ca.on.oicr.gsi.cardea.server.controller;
 import ca.on.oicr.gsi.cardea.server.service.CaseService;
 import ca.on.oicr.gsi.cardea.data.CaseData;
 import ca.on.oicr.gsi.cardea.data.CaseStatusesForRun;
-import ca.on.oicr.gsi.cardea.data.DjerbaCases;
+import ca.on.oicr.gsi.cardea.data.CasesForRequisition;
 import ca.on.oicr.gsi.cardea.data.ShesmuCase;
 
 import java.time.ZonedDateTime;
@@ -42,16 +42,16 @@ public class CardeaApiController {
     }
   }
 
-  @GetMapping("/djerba-cases/{requisitionName}")
-  public DjerbaCases getDjerbaCases(@PathVariable String requisitionName) {
+  @GetMapping("/requisition-cases/{requisitionName}")
+  public CasesForRequisition getCasesForRequisition(@PathVariable String requisitionName) {
     if (requisitionName == null || requisitionName.isBlank()) {
       throw new BadRequestException("must provide requisition name in URL");
     }
-    DjerbaCases djerbaCases = caseService.getDjerbaCases(requisitionName);
-    if (djerbaCases == null) {
+    CasesForRequisition casesForRequisition = caseService.getCasesForRequisition(requisitionName);
+    if (casesForRequisition == null) {
       throw new NotFoundException("could not find requisition with name " + requisitionName);
     }
-    return djerbaCases;
+    return casesForRequisition;
   }
 
   @GetMapping("/shesmu-cases")

--- a/cardea-server/src/main/java/ca/on/oicr/gsi/cardea/server/controller/CardeaApiController.java
+++ b/cardea-server/src/main/java/ca/on/oicr/gsi/cardea/server/controller/CardeaApiController.java
@@ -11,12 +11,10 @@ import java.time.ZonedDateTime;
 import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/")
@@ -46,13 +44,12 @@ public class CardeaApiController {
 
   @GetMapping("/djerba-cases/{requisitionName}")
   public DjerbaCases getDjerbaCases(@PathVariable String requisitionName) {
-    if (requisitionName == null) {
-      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "must provide requisition name in URL");
+    if (requisitionName == null || requisitionName.isBlank()) {
+      throw new BadRequestException("must provide requisition name in URL");
     }
     DjerbaCases djerbaCases = caseService.getDjerbaCases(requisitionName);
     if (djerbaCases == null) {
-      throw new ResponseStatusException(HttpStatus.NOT_FOUND,
-          "could not find requisition with name " + requisitionName);
+      throw new NotFoundException("could not find requisition with name " + requisitionName);
     }
     return djerbaCases;
   }

--- a/cardea-server/src/main/java/ca/on/oicr/gsi/cardea/server/controller/CardeaApiController.java
+++ b/cardea-server/src/main/java/ca/on/oicr/gsi/cardea/server/controller/CardeaApiController.java
@@ -45,11 +45,11 @@ public class CardeaApiController {
   @GetMapping("/requisition-cases/{requisitionName}")
   public CasesForRequisition getCasesForRequisition(@PathVariable String requisitionName) {
     if (requisitionName == null || requisitionName.isBlank()) {
-      throw new BadRequestException("must provide requisition name in URL");
+      throw new BadRequestException("missing requisition name in URL");
     }
     CasesForRequisition casesForRequisition = caseService.getCasesForRequisition(requisitionName);
     if (casesForRequisition == null) {
-      throw new NotFoundException("could not find requisition with name " + requisitionName);
+      throw new NotFoundException(String.format("could not find requisition with name '%s'", requisitionName));
     }
     return casesForRequisition;
   }

--- a/cardea-server/src/main/java/ca/on/oicr/gsi/cardea/server/controller/CardeaApiController.java
+++ b/cardea-server/src/main/java/ca/on/oicr/gsi/cardea/server/controller/CardeaApiController.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.cardea.server.controller;
 import ca.on.oicr.gsi.cardea.server.service.CaseService;
 import ca.on.oicr.gsi.cardea.data.CaseData;
 import ca.on.oicr.gsi.cardea.data.CaseStatusesForRun;
+import ca.on.oicr.gsi.cardea.data.DjerbaCases;
 import ca.on.oicr.gsi.cardea.data.ShesmuCase;
 
 import java.time.ZonedDateTime;
@@ -10,10 +11,12 @@ import java.time.ZonedDateTime;
 import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/")
@@ -39,6 +42,19 @@ public class CardeaApiController {
     } else {
       return caseData.getTimestamp();
     }
+  }
+
+  @GetMapping("/djerba-cases/{requisitionName}")
+  public DjerbaCases getDjerbaCases(@PathVariable String requisitionName) {
+    if (requisitionName == null) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "must provide requisition name in URL");
+    }
+    DjerbaCases djerbaCases = caseService.getDjerbaCases(requisitionName);
+    if (djerbaCases == null) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+          "could not find requisition with name " + requisitionName);
+    }
+    return djerbaCases;
   }
 
   @GetMapping("/shesmu-cases")

--- a/cardea-server/src/main/java/ca/on/oicr/gsi/cardea/server/service/CaseService.java
+++ b/cardea-server/src/main/java/ca/on/oicr/gsi/cardea/server/service/CaseService.java
@@ -135,9 +135,7 @@ public class CaseService {
         .findFirst().get();
 
     Assay assay = caseData.getAssaysById().get(assayId);
-    if (cases.isEmpty() || assayId == null) {
-      return null;
-    }
+
     return new CasesForRequisition.Builder()
         .assayName(assay.getName())
         .assayVersion(assay.getVersion())

--- a/cardea-server/src/main/java/ca/on/oicr/gsi/cardea/server/service/CaseService.java
+++ b/cardea-server/src/main/java/ca/on/oicr/gsi/cardea/server/service/CaseService.java
@@ -127,6 +127,9 @@ public class CaseService {
     Set<Case> cases = caseData.getCases().stream()
         .filter(kase -> requisitionName.equals(kase.getRequisition().getName()))
         .collect(Collectors.toSet());
+    if (cases.isEmpty()) {
+      return null;
+    }
     Long assayId = cases.stream()
         .map(kase -> kase.getRequisition().getAssayId())
         .findFirst().get();

--- a/cardea-server/src/main/java/ca/on/oicr/gsi/cardea/server/service/CaseService.java
+++ b/cardea-server/src/main/java/ca/on/oicr/gsi/cardea/server/service/CaseService.java
@@ -1,9 +1,11 @@
 package ca.on.oicr.gsi.cardea.server.service;
 
+import ca.on.oicr.gsi.cardea.data.Assay;
 import ca.on.oicr.gsi.cardea.data.Case;
 import ca.on.oicr.gsi.cardea.data.CaseData;
 import ca.on.oicr.gsi.cardea.data.CaseStatus;
 import ca.on.oicr.gsi.cardea.data.CaseStatusesForRun;
+import ca.on.oicr.gsi.cardea.data.DjerbaCases;
 import ca.on.oicr.gsi.cardea.data.Requisition;
 import ca.on.oicr.gsi.cardea.data.RequisitionQc;
 import ca.on.oicr.gsi.cardea.data.Run;
@@ -15,9 +17,7 @@ import ca.on.oicr.gsi.Pair;
 
 import java.time.Duration;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
-import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -25,9 +25,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
@@ -123,6 +121,25 @@ public class CaseService {
         })
         .flatMap(Set::stream)
         .collect(Collectors.toSet());
+  }
+
+  public DjerbaCases getDjerbaCases(String requisitionName) {
+    Set<Case> cases = caseData.getCases().stream()
+        .filter(kase -> requisitionName.equals(kase.getRequisition().getName()))
+        .collect(Collectors.toSet());
+    Long assayId = cases.stream()
+        .map(kase -> kase.getRequisition().getAssayId())
+        .findFirst().get();
+
+    Assay assay = caseData.getAssaysById().get(assayId);
+    if (cases.isEmpty() || assayId == null) {
+      return null;
+    }
+    return new DjerbaCases.Builder()
+        .assayName(assay.getName())
+        .assayVersion(assay.getVersion())
+        .cases(cases)
+        .build();
   }
 
   public Set<ShesmuCase> getShesmuCases() {

--- a/cardea-server/src/main/java/ca/on/oicr/gsi/cardea/server/service/CaseService.java
+++ b/cardea-server/src/main/java/ca/on/oicr/gsi/cardea/server/service/CaseService.java
@@ -5,7 +5,7 @@ import ca.on.oicr.gsi.cardea.data.Case;
 import ca.on.oicr.gsi.cardea.data.CaseData;
 import ca.on.oicr.gsi.cardea.data.CaseStatus;
 import ca.on.oicr.gsi.cardea.data.CaseStatusesForRun;
-import ca.on.oicr.gsi.cardea.data.DjerbaCases;
+import ca.on.oicr.gsi.cardea.data.CasesForRequisition;
 import ca.on.oicr.gsi.cardea.data.Requisition;
 import ca.on.oicr.gsi.cardea.data.RequisitionQc;
 import ca.on.oicr.gsi.cardea.data.Run;
@@ -123,7 +123,7 @@ public class CaseService {
         .collect(Collectors.toSet());
   }
 
-  public DjerbaCases getDjerbaCases(String requisitionName) {
+  public CasesForRequisition getCasesForRequisition(String requisitionName) {
     Set<Case> cases = caseData.getCases().stream()
         .filter(kase -> requisitionName.equals(kase.getRequisition().getName()))
         .collect(Collectors.toSet());
@@ -138,7 +138,7 @@ public class CaseService {
     if (cases.isEmpty() || assayId == null) {
       return null;
     }
-    return new DjerbaCases.Builder()
+    return new CasesForRequisition.Builder()
         .assayName(assay.getName())
         .assayVersion(assay.getVersion())
         .cases(cases)

--- a/cardea-server/src/main/resources/application.yml
+++ b/cardea-server/src/main/resources/application.yml
@@ -18,7 +18,7 @@ server:
   use-forwarded-headers: true
   forward-headers-strategy: framework
   error:
-    include-stacktrace: on_param
+    include-stacktrace: never
 
 build:
   version: "@project.version@"

--- a/cardea-server/src/main/resources/application.yml
+++ b/cardea-server/src/main/resources/application.yml
@@ -17,6 +17,8 @@ spring:
 server:
   use-forwarded-headers: true
   forward-headers-strategy: framework
+  error:
+    include-stacktrace: on_param
 
 build:
   version: "@project.version@"

--- a/changes/add_djerbacases.md
+++ b/changes/add_djerbacases.md
@@ -1,1 +1,1 @@
-Add `/djerba-cases/{requisitionName}` endpoint
+Add `/requisition-cases/{requisitionName}` endpoint

--- a/changes/add_djerbacases.md
+++ b/changes/add_djerbacases.md
@@ -1,0 +1,1 @@
+Add `/djerba-cases/{requisitionName}` endpoint


### PR DESCRIPTION
Jira ticket: GP-3950

This will allow CGI to automate much of the work they presently do manually, and enable fishing expeditions/programmatic verification of assumptions.

- [x] Includes a change file
- [x] Updates developer documentation (API docs now show `assaysById` in `CaseData`, and also the new endpoint
