### PR TITLE
remove stopped option for status in shesmu detailed case

### DIFF
--- a/cardea-server/src/main/java/ca/on/oicr/gsi/cardea/server/service/CaseService.java
+++ b/cardea-server/src/main/java/ca/on/oicr/gsi/cardea/server/service/CaseService.java
@@ -89,7 +89,13 @@ public class CaseService {
   private CaseStatus getCaseStatus(Case kase) {
     if (kase.isStopped()) {
       return CaseStatus.STOPPED;
-    } else if (!kase.getDeliverables().isEmpty() && kase.getDeliverables().stream()
+    } else {
+      return getCaseCompletion(kase);
+    }
+  }
+
+  private CaseStatus getCaseCompletion(Case kase) {
+     if (!kase.getDeliverables().isEmpty() && kase.getDeliverables().stream()
         .allMatch(deliverable -> deliverable.getReleases().stream()
             .allMatch(release -> {
               ReleaseQcStatus status = release.getQcStatus();
@@ -100,6 +106,7 @@ public class CaseService {
       return CaseStatus.ACTIVE;
     }
   }
+
 
   private Set<String> getRunNamesFor(Case kase) {
     return kase.getTests().stream()
@@ -264,7 +271,7 @@ public class CaseService {
         .assayName(caseData.getAssaysById().get(kase.getAssayId()).getName())
         .assayVersion(caseData.getAssaysById().get(kase.getAssayId()).getVersion())
         .caseIdentifier(kase.getId())
-        .caseStatus(getCaseStatus(kase))
+        .caseStatus(getCaseCompletion(kase))
         .paused(kase.getRequisition().isPaused())
         .stopped(kase.getRequisition().isStopped())
         .completedDateLocal(getCompletedDate(kase, false))

--- a/changes/change_status_options_for_shesmu_detailed_case
+++ b/changes/change_status_options_for_shesmu_detailed_case
@@ -1,0 +1,1 @@
+Shesmu Detailed Case status can only be ACTIVE or COMPLETE, not STOPPED


### PR DESCRIPTION
Jira ticket: https://jira.oicr.on.ca/browse/GP-4575

- [x] Includes a change file
- [ ] Updates developer documentation
- [ ] If `shesmu-cases` or `shesmu-detailed-cases` data models have changed, open a PR which updates the data models in the infrastructure benchmarking script.
  - infrastructure PR should have a title like "Merge during Cardea release: [rest of the title]" and BL will merge during release
