### PR TITLE
sort shesmu detailed case sequencing elements

### DIFF
--- a/cardea-server/src/main/java/ca/on/oicr/gsi/cardea/server/service/CaseService.java
+++ b/cardea-server/src/main/java/ca/on/oicr/gsi/cardea/server/service/CaseService.java
@@ -147,7 +147,10 @@ public class CaseService {
 
   private Set<ShesmuSequencing> getSequencingForShesmuCase(Case kase) {
 
-    TreeSet<ShesmuSequencing> sequencings =  new TreeSet<>(Comparator.comparing(ShesmuSequencing::getTest));
+    TreeSet<ShesmuSequencing> sequencings =  new TreeSet<>(Comparator.comparing(ShesmuSequencing::getTest)
+        .thenComparing(shesmuSequencing -> shesmuSequencing.getLimsIds().stream()
+            .map(ShesmuSample::getId)
+            .collect(Collectors.joining(","))));
 
     final long reqId = kase.getRequisition().getId();
 

--- a/cardea-server/src/main/java/ca/on/oicr/gsi/cardea/server/service/CaseService.java
+++ b/cardea-server/src/main/java/ca/on/oicr/gsi/cardea/server/service/CaseService.java
@@ -147,7 +147,8 @@ public class CaseService {
 
   private Set<ShesmuSequencing> getSequencingForShesmuCase(Case kase) {
 
-    Set<ShesmuSequencing> sequencings = new HashSet<>();
+    TreeSet<ShesmuSequencing> sequencings =  new TreeSet<>(Comparator.comparing(ShesmuSequencing::getTest));
+
     final long reqId = kase.getRequisition().getId();
 
     for (Test test : kase.getTests()) {
@@ -171,7 +172,7 @@ public class CaseService {
   private ShesmuSequencing makeShesmuSequencing(List<Sample> samples, MetricCategory type,
       long reqId, String name) {
 
-    Set<ShesmuSample> shesmuSamples = new HashSet<>();
+    TreeSet<ShesmuSample> shesmuSamples = new TreeSet<>(Comparator.comparing(ShesmuSample::getId));
 
     boolean hasPassed = false;
     boolean hasWaiting = false;

--- a/cardea-server/src/main/java/ca/on/oicr/gsi/cardea/server/service/CaseService.java
+++ b/cardea-server/src/main/java/ca/on/oicr/gsi/cardea/server/service/CaseService.java
@@ -147,9 +147,10 @@ public class CaseService {
 
   private Set<ShesmuSequencing> getSequencingForShesmuCase(Case kase) {
 
+
     TreeSet<ShesmuSequencing> sequencings =  new TreeSet<>(Comparator.comparing(ShesmuSequencing::getTest)
         .thenComparing(shesmuSequencing -> shesmuSequencing.getLimsIds().stream()
-            .map(ShesmuSample::getId)
+            .map(ShesmuSample::getId) //IDs are sorted as part of makeShesmuSequencing
             .collect(Collectors.joining(","))));
 
     final long reqId = kase.getRequisition().getId();

--- a/changes/change_shesmu-detailed-case_sequencing.md
+++ b/changes/change_shesmu-detailed-case_sequencing.md
@@ -1,0 +1,1 @@
+shesmu-detailed-case endpoint sequencing field will be sorted  


### PR DESCRIPTION
Jira ticket: https://jira.oicr.on.ca/browse/GP-4603

- [ x] Includes a change file
- [ ] Updates developer documentation
- [ ] If `shesmu-cases` or `shesmu-detailed-cases` data models have changed, open a PR which updates the data models in the infrastructure benchmarking script.
  - infrastructure PR should have a title like "Merge during Cardea release: [rest of the title]" and BL will merge during release
