### PR TITLE
[GLT-4390] added new metric objects to sample model

### DIFF
--- a/cardea-data/src/main/java/ca/on/oicr/gsi/cardea/data/Sample.java
+++ b/cardea-data/src/main/java/ca/on/oicr/gsi/cardea/data/Sample.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -69,6 +70,7 @@ public class Sample {
   private final Integer peReads;
   private final LocalDate transferDate;
   private final BigDecimal dv200;
+  private final List<SampleMetric> metrics;
 
   private Sample(Builder builder) {
     this.id = requireNonNull(builder.id);
@@ -130,6 +132,7 @@ public class Sample {
     }
     this.transferDate = builder.transferDate;
     this.dv200 = builder.dv200;
+    this.metrics = Collections.unmodifiableList(builder.metrics);
   }
 
   @Override
@@ -358,6 +361,10 @@ public class Sample {
     return dv200;
   }
 
+  public List<SampleMetric> getMetrics() {
+    return metrics;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(id, run, sequencingLane);
@@ -419,6 +426,7 @@ public class Sample {
     private LocalDate latestActivityDate;
     private LocalDate transferDate;
     private BigDecimal dv200;
+    private List<SampleMetric> metrics;
 
     public Sample build() {
       return new Sample(this);
@@ -695,6 +703,11 @@ public class Sample {
 
     public Builder dv200(BigDecimal dv200) {
       this.dv200 = dv200;
+      return this;
+    }
+
+    public Builder metrics(List<SampleMetric> metrics) {
+      this.metrics = metrics;
       return this;
     }
 

--- a/cardea-data/src/main/java/ca/on/oicr/gsi/cardea/data/SampleMetric.java
+++ b/cardea-data/src/main/java/ca/on/oicr/gsi/cardea/data/SampleMetric.java
@@ -1,0 +1,154 @@
+package ca.on.oicr.gsi.cardea.data;
+
+import static java.util.Objects.requireNonNull;
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.Set;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+/**
+ * Immutable SampleMetric
+ */
+@JsonDeserialize(builder = SampleMetric.Builder.class)
+public class SampleMetric {
+
+  public static enum MetricLevel {
+    SAMPLE, RUN, LANE
+  }
+
+  private final String name;
+  private final ThresholdType thresholdType;
+  private final BigDecimal minimum;
+  private final BigDecimal maximum;
+  private final MetricLevel metricLevel;
+  private final Boolean preliminary;
+  private final BigDecimal value;
+  private final Set<SampleMetricLane> laneValues;
+  private final Boolean qcPassed;
+  private final String units;
+
+  private SampleMetric(Builder builder) {
+    this.name = requireNonNull(builder.name);
+    this.thresholdType = requireNonNull(builder.thresholdType);
+    this.minimum = builder.minimum;
+    this.maximum = builder.maximum;
+    this.metricLevel = requireNonNull(builder.metricLevel);
+    this.preliminary = builder.preliminary;
+    this.value = builder.value;
+    this.laneValues =
+        builder.laneValues == null ? null : Collections.unmodifiableSet(builder.laneValues);
+    this.qcPassed = builder.qcPassed;
+    this.units = builder.units;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public ThresholdType getThresholdType() {
+    return thresholdType;
+  }
+
+  public BigDecimal getMinimum() {
+    return minimum;
+  }
+
+  public BigDecimal getMaximum() {
+    return maximum;
+  }
+
+  public MetricLevel getMetricLevel() {
+    return metricLevel;
+  }
+
+  public Boolean getPreliminary() {
+    return preliminary;
+  }
+
+  public BigDecimal getValue() {
+    return value;
+  }
+
+  public Set<SampleMetricLane> getLaneValues() {
+    return laneValues;
+  }
+
+  public Boolean getQcPassed() {
+    return qcPassed;
+  }
+
+  public String getUnits() {
+    return units;
+  }
+
+  @JsonPOJOBuilder(withPrefix = "")
+  public static class Builder {
+
+    private String name;
+    private ThresholdType thresholdType;
+    private BigDecimal minimum;
+    private BigDecimal maximum;
+    private MetricLevel metricLevel;
+    private Boolean preliminary;
+    private BigDecimal value;
+    private Set<SampleMetricLane> laneValues;
+    private Boolean qcPassed;
+    private String units;
+
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public Builder thresholdType(ThresholdType thresholdType) {
+      this.thresholdType = thresholdType;
+      return this;
+    }
+
+    public Builder minimum(BigDecimal minimum) {
+      this.minimum = minimum;
+      return this;
+    }
+
+    public Builder maximum(BigDecimal maximum) {
+      this.maximum = maximum;
+      return this;
+    }
+
+    public Builder metricLevel(MetricLevel metricLevel) {
+      this.metricLevel = metricLevel;
+      return this;
+    }
+
+    public Builder preliminary(Boolean preliminary) {
+      this.preliminary = preliminary;
+      return this;
+    }
+
+    public Builder value(BigDecimal value) {
+      this.value = value;
+      return this;
+    }
+
+    public Builder laneValues(Set<SampleMetricLane> laneValues) {
+      this.laneValues = laneValues;
+      return this;
+    }
+
+    public Builder qcPassed(Boolean qcPassed) {
+      this.qcPassed = qcPassed;
+      return this;
+    }
+
+    public Builder units(String units) {
+      this.units = units;
+      return this;
+    }
+
+    public SampleMetric build() {
+      return new SampleMetric(this);
+    }
+
+  }
+}

--- a/cardea-data/src/main/java/ca/on/oicr/gsi/cardea/data/SampleMetricLane.java
+++ b/cardea-data/src/main/java/ca/on/oicr/gsi/cardea/data/SampleMetricLane.java
@@ -1,0 +1,39 @@
+package ca.on.oicr.gsi.cardea.data;
+
+import java.math.BigDecimal;
+
+/**
+ * Immutable SampleMetricLane
+ */
+public class SampleMetricLane {
+
+  private final int laneNumber;
+  private final BigDecimal laneValue;
+  private final BigDecimal read1Value;
+  private final BigDecimal read2Value;
+
+  public SampleMetricLane(int laneNumber, BigDecimal laneValue, BigDecimal read1Value,
+      BigDecimal read2Value) {
+    this.laneNumber = laneNumber;
+    this.laneValue = laneValue;
+    this.read1Value = read1Value;
+    this.read2Value = read2Value;
+  }
+
+  public int getLaneNumber() {
+    return laneNumber;
+  }
+
+  public BigDecimal getLaneValue() {
+    return laneValue;
+  }
+
+  public BigDecimal getRead1Value() {
+    return read1Value;
+  }
+
+  public BigDecimal getRead2Value() {
+    return read2Value;
+  }
+
+}

--- a/cardea-server/src/test/java/ca/on/oicr/gsi/cardea/server/CaseLoaderTest.java
+++ b/cardea-server/src/test/java/ca/on/oicr/gsi/cardea/server/CaseLoaderTest.java
@@ -22,7 +22,11 @@ import ca.on.oicr.gsi.cardea.data.Requisition;
 import ca.on.oicr.gsi.cardea.data.AnalysisQcGroup;
 import ca.on.oicr.gsi.cardea.data.Run;
 import ca.on.oicr.gsi.cardea.data.Sample;
+import ca.on.oicr.gsi.cardea.data.SampleMetric;
+import ca.on.oicr.gsi.cardea.data.SampleMetricLane;
+import ca.on.oicr.gsi.cardea.data.ThresholdType;
 import ca.on.oicr.gsi.cardea.data.CaseQc.AnalysisReviewQcStatus;
+import ca.on.oicr.gsi.cardea.data.SampleMetric.MetricLevel;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -120,6 +124,37 @@ public class CaseLoaderTest {
     assertEquals(new BigDecimal("0.65"), lane1.getPercentPfixRead2());
   }
 
+  private static void assertRunSample(Sample sample) {
+    assertEquals("5476_1_LDI73620", sample.getId());
+    assertEquals("PROJ_1289_Ly_R_PE_567_WG", sample.getName());
+    assertEquals(Boolean.TRUE, sample.getQcPassed());
+    assertNotNull(sample.getMetrics());
+    assertEquals(1, sample.getMetrics().size());
+    SampleMetric metric = sample.getMetrics().get(0);
+    assertEquals("Bases Over Q30", metric.getName());
+    assertEquals(ThresholdType.GT, metric.getThresholdType());
+    assertEquals(MetricLevel.RUN, metric.getMetricLevel());
+    assertEquals(new BigDecimal("75.0"), metric.getMinimum());
+    assertNull(metric.getMaximum());
+    assertEquals(new BigDecimal("89.1"), metric.getValue());
+    assertNotNull(metric.getLaneValues());
+    assertEquals(2, metric.getLaneValues().size());
+    SampleMetricLane lane1 = metric.getLaneValues().stream()
+        .filter(x -> x.getLaneNumber() == 1)
+        .findAny().orElse(null);
+    assertNotNull(lane1);
+    assertNull(lane1.getLaneValue());
+    assertEquals(new BigDecimal("90.0"), lane1.getRead1Value());
+    assertEquals(new BigDecimal("88.0"), lane1.getRead2Value());
+    SampleMetricLane lane2 = metric.getLaneValues().stream()
+        .filter(x -> x.getLaneNumber() == 2)
+        .findAny().orElse(null);
+    assertNotNull(lane2);
+    assertNull(lane2.getLaneValue());
+    assertEquals(new BigDecimal("90.0"), lane2.getRead1Value());
+    assertEquals(new BigDecimal("88.0"), lane2.getRead2Value());
+  }
+
   private static void assertOmittedRunSample(OmittedRunSample sample) {
     assertEquals("5459_1_LDI36185", sample.getId());
     assertEquals("MISS_011408_Co_P_PE_490_WG", sample.getName());
@@ -183,9 +218,7 @@ public class CaseLoaderTest {
     assertNotNull(test.getFullDepthSequencings());
     assertEquals(1, test.getFullDepthSequencings().size());
     Sample fullDepth = test.getFullDepthSequencings().get(0);
-    assertEquals("5476_1_LDI73620", fullDepth.getId());
-    assertEquals("PROJ_1289_Ly_R_PE_567_WG", fullDepth.getName());
-    assertEquals(Boolean.TRUE, fullDepth.getQcPassed());
+    assertRunSample(fullDepth);
     assertEquals(1, test.getExtractionDaysSpent());
     assertEquals(0, test.getExtractionPreparationDaysSpent());
     assertEquals(0, test.getExtractionQcDaysSpent());

--- a/cardea-server/src/test/java/ca/on/oicr/gsi/cardea/server/service/CaseServiceTest.java
+++ b/cardea-server/src/test/java/ca/on/oicr/gsi/cardea/server/service/CaseServiceTest.java
@@ -60,13 +60,19 @@ public class CaseServiceTest {
     // here too
     if (runName == null) {
       newSample = new Sample.Builder().id(name).name(name).donor(mock(Donor.class)).project("PROJ")
-          .tissueOrigin("To").tissueType("T")
-          .createdDate(LocalDate.now()).build();
+          .tissueOrigin("To")
+          .tissueType("T")
+          .metrics(new ArrayList<>())
+          .createdDate(LocalDate.now())
+          .build();
     } else {
       newSample = new Sample.Builder().id(name).name(name).donor(mock(Donor.class)).project("PROJ")
-          .tissueOrigin("To").tissueType("T")
+          .tissueOrigin("To")
+          .tissueType("T")
           .run(new Run.Builder().name(runName).lanes(new ArrayList<>()).build())
-          .createdDate(LocalDate.now()).build();
+          .metrics(new ArrayList<>())
+          .createdDate(LocalDate.now())
+          .build();
     }
 
     collection.add(newSample);

--- a/cardea-server/src/test/resources/testdata/samples.json
+++ b/cardea-server/src/test/resources/testdata/samples.json
@@ -53,7 +53,8 @@
     "rrna_contamination": null,
     "mapped_to_coding": null,
     "raw_coverage": null,
-    "on_target_reads": null
+    "on_target_reads": null,
+    "metrics": []
   },
   {
     "sample_id": "SAM413641",
@@ -109,7 +110,8 @@
     "rrna_contamination": null,
     "mapped_to_coding": null,
     "raw_coverage": null,
-    "on_target_reads": null
+    "on_target_reads": null,
+    "metrics": []
   },
   {
     "sample_id": "SAM413643",
@@ -165,7 +167,8 @@
     "rrna_contamination": null,
     "mapped_to_coding": null,
     "raw_coverage": null,
-    "on_target_reads": null
+    "on_target_reads": null,
+    "metrics": []
   },
   {
     "sample_id": "SAM413645",
@@ -221,7 +224,8 @@
     "rrna_contamination": null,
     "mapped_to_coding": null,
     "raw_coverage": null,
-    "on_target_reads": null
+    "on_target_reads": null,
+    "metrics": []
   },
   {
     "sample_id": "SAM413647",
@@ -277,7 +281,8 @@
     "rrna_contamination": null,
     "mapped_to_coding": null,
     "raw_coverage": null,
-    "on_target_reads": null
+    "on_target_reads": null,
+    "metrics": []
   },
   {
     "sample_id": "SAM413593",
@@ -333,7 +338,8 @@
     "rrna_contamination": null,
     "mapped_to_coding": null,
     "raw_coverage": null,
-    "on_target_reads": null
+    "on_target_reads": null,
+    "metrics": []
   },
   {
     "sample_id": "LIB75802",
@@ -390,7 +396,8 @@
     "rrna_contamination": null,
     "mapped_to_coding": null,
     "raw_coverage": null,
-    "on_target_reads": null
+    "on_target_reads": null,
+    "metrics": []
   },
   {
     "sample_id": "5459_1_LDI73620",
@@ -446,7 +453,8 @@
     "rrna_contamination": null,
     "mapped_to_coding": null,
     "raw_coverage": null,
-    "on_target_reads": null
+    "on_target_reads": null,
+    "metrics": []
   },
   {
     "sample_id": "5467_1_LDI73620",
@@ -499,7 +507,8 @@
     "rrna_contamination": null,
     "mapped_to_coding": null,
     "raw_coverage": null,
-    "on_target_reads": null
+    "on_target_reads": null,
+    "metrics": []
   },
   {
     "sample_id": "5476_1_LDI73620",
@@ -555,7 +564,30 @@
     "rrna_contamination": null,
     "mapped_to_coding": null,
     "raw_coverage": null,
-    "on_target_reads": null
+    "on_target_reads": null,
+    "metrics": [
+      {
+        "name": "Bases Over Q30",
+        "threshold_type": "GT",
+        "threshold_min": 75.0,
+        "threshold_max": null,
+        "metric_level": "RUN",
+        "preliminary": null,
+        "run_values": {
+          "1": {
+            "R1": 90.0,
+            "R2": 88.0
+          },
+          "2": {
+            "R1": 90.0,
+            "R2": 88.0
+          }
+        },
+        "value": 89.1,
+        "qc_passed": true,
+        "units": "%"
+      }
+    ]
   },
   {
     "sample_id": "SAM413648",
@@ -611,7 +643,8 @@
     "rrna_contamination": null,
     "mapped_to_coding": null,
     "raw_coverage": null,
-    "on_target_reads": null
+    "on_target_reads": null,
+    "metrics": []
   },
   {
     "sample_id": "LIB76197",
@@ -668,7 +701,8 @@
     "rrna_contamination": null,
     "mapped_to_coding": null,
     "raw_coverage": null,
-    "on_target_reads": null
+    "on_target_reads": null,
+    "metrics": []
   },
   {
     "sample_id": "LIB75803",
@@ -725,7 +759,8 @@
     "rrna_contamination": null,
     "mapped_to_coding": null,
     "raw_coverage": null,
-    "on_target_reads": null
+    "on_target_reads": null,
+    "metrics": []
   },
   {
     "sample_id": "5460_1_LDI73998",
@@ -781,7 +816,8 @@
     "rrna_contamination": null,
     "mapped_to_coding": null,
     "raw_coverage": null,
-    "on_target_reads": null
+    "on_target_reads": null,
+    "metrics": []
   },
   {
     "sample_id": "5459_1_LDI73621",
@@ -837,7 +873,8 @@
     "rrna_contamination": null,
     "mapped_to_coding": null,
     "raw_coverage": null,
-    "on_target_reads": null
+    "on_target_reads": null,
+    "metrics": []
   },
   {
     "sample_id": "5467_1_LDI73621",
@@ -893,7 +930,8 @@
     "rrna_contamination": null,
     "mapped_to_coding": null,
     "raw_coverage": null,
-    "on_target_reads": null
+    "on_target_reads": null,
+    "metrics": []
   },
   {
     "sample_id": "5481_1_LDI73998",
@@ -949,7 +987,8 @@
     "rrna_contamination": 3.6213356920990045,
     "mapped_to_coding": 27.0237,
     "raw_coverage": null,
-    "on_target_reads": null
+    "on_target_reads": null,
+    "metrics": []
   },
   {
     "sample_id": "5476_1_LDI73621",
@@ -1005,7 +1044,8 @@
     "rrna_contamination": null,
     "mapped_to_coding": null,
     "raw_coverage": null,
-    "on_target_reads": null
+    "on_target_reads": null,
+    "metrics": []
   },
   {
     "sample_id": "5540_1_LDI73621",
@@ -1061,7 +1101,8 @@
     "rrna_contamination": null,
     "mapped_to_coding": null,
     "raw_coverage": null,
-    "on_target_reads": null
+    "on_target_reads": null,
+    "metrics": []
   },
   {
     "sample_id": "SAM413735",
@@ -1117,6 +1158,7 @@
     "rrna_contamination": null,
     "mapped_to_coding": null,
     "raw_coverage": null,
-    "on_target_reads": null
+    "on_target_reads": null,
+    "metrics": []
   }
 ]

--- a/changes/add_samplemetric.md
+++ b/changes/add_samplemetric.md
@@ -1,0 +1,1 @@
+Metrics collection to samples, defining the metric properties, value(s), and status


### PR DESCRIPTION
Jira ticket: https://jira.oicr.on.ca/browse/GLT-4390

- [x] Includes a change file
- [x] Updates developer documentation
- [ ] If `shesmu-cases` or `shesmu-detailed-cases` data models have changed, open a PR which updates the data models in the infrastructure benchmarking script.
  - infrastructure PR should have a title like "Merge during Cardea release: [rest of the title]" and BL will merge during release
