### PR TITLE
stopped-and-released cases should be considered completed

### DIFF
--- a/cardea-server/src/main/java/ca/on/oicr/gsi/cardea/server/service/CaseService.java
+++ b/cardea-server/src/main/java/ca/on/oicr/gsi/cardea/server/service/CaseService.java
@@ -99,11 +99,12 @@ public class CaseService {
   }
 
   private CaseStatus getCaseStatus(Case kase) {
-    if (kase.isStopped()) {
+    CaseStatus status = getCaseCompletion(kase);
+    // If the case is active, the stopped status takes precedence
+    if (status.equals(CaseStatus.ACTIVE) && kase.isStopped()) {
       return CaseStatus.STOPPED;
-    } else {
-      return getCaseCompletion(kase);
     }
+    return status;
   }
 
   private CaseStatus getCaseCompletion(Case kase) {

--- a/cardea-server/src/test/java/ca/on/oicr/gsi/cardea/server/service/CaseServiceTest.java
+++ b/cardea-server/src/test/java/ca/on/oicr/gsi/cardea/server/service/CaseServiceTest.java
@@ -141,16 +141,16 @@ public class CaseServiceTest {
   @org.junit.jupiter.api.Test
   public void testGetCaseCountsForRun_oneMatchingRun() {
     CaseStatusesForRun matches = sut.getCaseStatusesForRun("Run1");
-    assertEquals(0, matches.getCompletedCases().size());
-    assertEquals(1, matches.getStoppedCases().size());
+    assertEquals(1, matches.getCompletedCases().size());
+    assertEquals(0, matches.getStoppedCases().size());
     assertEquals(0, matches.getActiveCases().size());
   }
 
   @org.junit.jupiter.api.Test
   public void testGetCaseCountsForRun_twoMatchingRuns() {
     CaseStatusesForRun matches = sut.getCaseStatusesForRun("Run2");
-    assertEquals(1, matches.getCompletedCases().size());
-    assertEquals(1, matches.getStoppedCases().size());
+    assertEquals(2, matches.getCompletedCases().size());
+    assertEquals(0, matches.getStoppedCases().size());
     assertEquals(0, matches.getActiveCases().size());
   }
 

--- a/changes/change_stopped_and_released.md
+++ b/changes/change_stopped_and_released.md
@@ -1,0 +1,1 @@
+stopped and released cases are now considered completed


### PR DESCRIPTION
This applies to both statuses-by-run and shesmu-detailed-cases

Jira ticket: GP-5281

- [x] Includes a change file
- [x] Updates developer documentation (or N/A)
- [x] If `shesmu-cases` or `shesmu-detailed-cases` data models have changed, open a PR which updates the data models in the infrastructure benchmarking script.
  - infrastructure PR should have a title like "Merge during Cardea release: [rest of the title]" and BL will merge during release
